### PR TITLE
Additional cleanup of enum_av_excluded; support showing process and file extension exclusions

### DIFF
--- a/modules/post/windows/gather/enum_av_excluded.rb
+++ b/modules/post/windows/gather/enum_av_excluded.rb
@@ -60,18 +60,20 @@ class Metasploit3 < Msf::Post
     admin_exclusion_key = "#{base_exclusion_key}\\Admin"
     admin_exclusion_key = "#{base_exclusion_key}\\Client"
 
-    paths = []
+    admin_paths = []
     if (admin_exclusion_keys = registry_enumkeys(admin_exclusion_key))
       admin_exclusion_keys.map do |key|
-        paths << registry_getvaldata("#{admin_exclusion_key}\\#{key}", 'DirectoryName') + ' (admin)'
+        admin_paths << registry_getvaldata("#{admin_exclusion_key}\\#{key}", 'DirectoryName')
       end
+      print_exclusions_table(SEP, 'admin path', admin_paths)
     end
+    client_paths = []
     if (client_exclusion_keys = registry_enumkeys(client_exclusion_key))
       client_exclusion_keys.map do |key|
-        paths << registry_getvaldata("#{client_exclusion_key}\\#{key}", 'DirectoryName') + ' (client)'
+        client_paths << registry_getvaldata("#{client_exclusion_key}\\#{key}", 'DirectoryName')
       end
     end
-    print_exclusions_table(SEP, 'path', paths)
+    print_exclusions_table(SEP, 'client path', client_paths)
   end
 
   def excluded_defender

--- a/modules/post/windows/gather/enum_av_excluded.rb
+++ b/modules/post/windows/gather/enum_av_excluded.rb
@@ -27,20 +27,23 @@ class Metasploit3 < Msf::Post
 
     register_options(
       [
-        OptBool.new('DEFENDER', [true, 'Enumerate exclusions for Microsoft Defener', true]),
+        OptBool.new('DEFENDER', [true, 'Enumerate exclusions for Microsoft Defender', true]),
         OptBool.new('ESSENTIALS', [true, 'Enumerate exclusions for Microsoft Security Essentials/Antimalware', true]),
         OptBool.new('SEP', [true, 'Enumerate exclusions for Symantec Endpoint Protection (SEP)', true])
       ]
     )
   end
 
+  DEFENDER = 'Windows Defender'
   DEFENDER_BASE_KEY = 'HKLM\\SOFTWARE\\Microsoft\\Windows Defender'
+  ESSENTIALS = 'Microsoft Security Essentials / Antimalware'
   ESSENTIALS_BASE_KEY = 'HKLM\\SOFTWARE\\Microsoft\\Microsoft Antimalware'
+  SEP = 'Symantec Endpoint Protection (SEP)'
   SEP_BASE_KEY = 'HKLM\\SOFTWARE\\Symantec\\Symantec Endpoint Protection'
 
   def av_installed?(base_key, product)
     if registry_key_exist?(base_key)
-      print_status("Found #{product}")
+      print_good("Found #{product}")
       true
     else
       false
@@ -48,77 +51,69 @@ class Metasploit3 < Msf::Post
   end
 
   def excluded_sep
-    print_status "Excluded Locations:"
-    keyadm = "HKLM\\SOFTWARE\\Symantec\\Symantec Endpoint Protection\\AV\\Exclusions\\ScanningEngines\\Directory\\Admin"
-    if (found_keysadm = registry_enumkeys(keyadm))
-      found_keysadm.each do |vals|
-        full = keyadm + "\\" + vals
-        values = registry_getvaldata(full, "DirectoryName")
-        print_good "#{values}"
-      end
-    else
-      print_error "No Admin Locations Found"
-    end
+    base_exclusion_key = "#{SEP_BASE_KEY}\\Exclusions\\ScanningEngines\\Directory"
+    admin_exclusion_key = "#{base_exclusion_key}\\Admin"
+    admin_exclusion_key = "#{base_exclusion_key}\\Client"
 
-    keycli = "HKLM\\SOFTWARE\\Symantec\\Symantec Endpoint Protection\\AV\\Exclusions\\ScanningEngines\\Directory\\Client"
-    if (found_keyscli = registry_enumkeys(keycli))
-      found_keyscli.each do |vals|
-        full = keycli + "\\" + vals
-        values = registry_getvaldata(full, "DirectoryName")
-        print_good "#{values}"
+    paths = []
+    if (admin_exclusion_keys = registry_enumkeys(admin_exclusion_key))
+      admin_exclusion_keys.map do |key|
+        paths << registry_getvaldata("#{admin_exclusion_key}\\#{key}", 'DirectoryName') + ' (admin)'
       end
-    else
-      print_error "No Client Locations Found"
     end
-  end
-
-  def excluded_mssec
-    print_status "Excluded Locations:"
-    keyms = "HKLM\\SOFTWARE\\Microsoft\\Microsoft Antimalware\\Exclusions\\Paths\\"
-    if (found = registry_enumvals(keyms))
-      found.each do |num|
-        print_good "#{num}"
+    if (client_exclusion_keys = registry_enumkeys(client_exclusion_key))
+      client_exclusion_keys.map do |key|
+        paths << registry_getvaldata("#{client_exclusion_key}\\#{key}", 'DirectoryName') + ' (client)'
       end
-    else
-      print_error "No Excluded Locations Found"
     end
+    print_exclusions_table(SEP, paths)
   end
 
   def excluded_defender
-    print_status "Excluded Locations:"
-    keyms = "HKLM\\SOFTWARE\\Microsoft\\Windows Defender\\Exclusions\\Paths\\"
-    if (found = registry_enumvals(keyms))
-      found.each do |num|
-        print_good "#{num}"
-      end
-    else
-      print_error "No Excluded Locations Found"
+    print_exclusions_table(DEFENDER, registry_enumvals("#{DEFENDER_BASE_KEY}\\Exclusions\\Paths"))
+  end
+
+  def excluded_mssec
+    print_exclusions_table(ESSENTIALS, registry_enumvals("#{ESSENTIALS_BASE_KEY}\\Exclusions\\Paths"))
+  end
+
+  def print_exclusions_table(product, exclusions)
+    unless exclusions && !exclusions.empty?
+      print_status("No exclusions for #{product}")
+      return
     end
+    table = Rex::Ui::Text::Table.new(
+      'Header'    => "#{product} excluded paths",
+      'Indent'    => 1,
+      'Columns'   => %w(path)
+    )
+    exclusions.map { |exclusion| table << [exclusion] }
+    print_line(table.to_s)
   end
 
   def setup
+    if sysinfo['Architecture'] =~ /WOW64/
+      fail_with(Failure::BadConfig, 'You are running this module from a 32-bit process on a 64-bit machine. ' \
+                'Migrate to a 64-bit process and try again')
+    end
     unless datastore['DEFENDER'] || datastore['ESSENTIALS'] || datastore['SEP']
       fail_with(Failure::BadConfig, 'Must set one or more of DEFENDER, ESSENTIALS or SEP to true')
     end
   end
 
   def run
-    if sysinfo['Architecture'] =~ /WOW64/
-      print_error "You are running this module from a 32-bit process on a 64-bit machine. Migrate to a 64-bit process and try again"
-      return
-    end
-
     print_status("Enumerating Excluded Paths for AV on #{sysinfo['Computer']}")
+
     found = false
-    if datastore['DEFENDER'] && av_installed?(DEFENDER_BASE_KEY, 'Microsoft Defender')
+    if datastore['DEFENDER'] && av_installed?(DEFENDER_BASE_KEY, DEFENDER)
       found = true
       excluded_defender
     end
-    if datastore['ESSENTIALS'] && av_installed?(ESSENTIALS_BASE_KEY, 'Microsoft Security Essentials / Antimalware')
+    if datastore['ESSENTIALS'] && av_installed?(ESSENTIALS_BASE_KEY, ESSENTIALS)
       found = true
       excluded_mssec
     end
-    if datastore['SEP'] && av_installed?(SEP_BASE_KEY, 'Symantec Endpoint Protection')
+    if datastore['SEP'] && av_installed?(SEP_BASE_KEY, SEP)
       found = true
       excluded_sep
     end

--- a/modules/post/windows/gather/enum_av_excluded.rb
+++ b/modules/post/windows/gather/enum_av_excluded.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Post
 
   def print_exclusions_table(product, exclusion_type, exclusions)
     exclusions ||= []
-    exclusions = exclusions.compact.reject { |e| e.blank? }
+    exclusions = exclusions.compact.reject(&:blank?)
     if exclusions.empty?
       print_status("No #{exclusion_type} exclusions for #{product}")
       return

--- a/modules/post/windows/gather/enum_av_excluded.rb
+++ b/modules/post/windows/gather/enum_av_excluded.rb
@@ -78,7 +78,9 @@ class Metasploit3 < Msf::Post
   end
 
   def print_exclusions_table(product, exclusions)
-    unless exclusions && !exclusions.empty?
+    exclusions ||= []
+    exclusions = exclusions.compact.reject { |e| e.blank? }
+    if exclusions.empty?
       print_status("No exclusions for #{product}")
       return
     end


### PR DESCRIPTION
For https://github.com/rapid7/metasploit-framework/pull/6197.  This cleans up and simplifies the code quite a bit, addressing all of my feedback so far.

As a bonus, this also adds support for showing the excluded file types (extensions) and processes, at least for the two MS products this supports.  I don't have access to SEP to test right now, but it should be simple assuming SEP supports this.

```
msf post(enum_av_excluded) > resource scripts/resource/run_all_post.rc
[*] Processing scripts/resource/run_all_post.rc for ERB directives.
[*] resource (scripts/resource/run_all_post.rc)> Ruby Code (189 bytes)
SESSION => 1
[*] Running post/windows/gather/enum_av_excluded against session 1

[*] Enumerating Excluded Paths for AV on ESSENTIALS-12-P
[+] Found Windows Defender
[*] No extension exclusions for Windows Defender
[*] No path exclusions for Windows Defender
[*] No process exclusions for Windows Defender
[+] Found Microsoft Security Essentials / Antimalware
[*] No extension exclusions for Microsoft Security Essentials / Antimalware
Microsoft Security Essentials / Antimalware excluded paths
==========================================================

 Path
 ----
 C:\cygwin

[*] No process exclusions for Microsoft Security Essentials / Antimalware
[*] Post module execution completed
SESSION => 2
[*] Running post/windows/gather/enum_av_excluded against session 2
[*] Enumerating Excluded Paths for AV on DEF2K8R2-P
[+] Found Windows Defender
[*] No extension exclusions for Windows Defender
Windows Defender excluded paths
===============================

 Path
 ----
 C:\cygwin

[*] No process exclusions for Windows Defender
[*] Post module execution completed
SESSION => 3
[*] Running post/windows/gather/enum_av_excluded against session 3
[*] Enumerating Excluded Paths for AV on ESSENTIALS-11-P
[+] Found Windows Defender
Windows Defender excluded extensions
====================================

 Extension
 ---------
 BLAH

Windows Defender excluded paths
===============================

 Path
 ----
 C:\cygwin\bin\bash.exe

[*] No process exclusions for Windows Defender
[*] Post module execution completed
```
